### PR TITLE
Updated docs with new syntax

### DIFF
--- a/examples/1-animating-lines.md
+++ b/examples/1-animating-lines.md
@@ -1,9 +1,7 @@
 # Final Code
 
 ```
-var w = window.WebAnim
+var line = Line({ form: w.Lines.SlopePoint, slope: 1, point: {x: 0, y: 0}, color: w.Colors.Green(), thickness: 5 })
 
-var line = new w.Line({ form: w.Lines.SlopePoint, slope: 1, point: {x: 0, y: 0}, color: w.Colors.Green(), thickness: 5 })
-
-w.scene.add(await w.Create(line, { duration: 10 }))
+scene.add(await Create(line, { duration: 10 }))
 ```

--- a/examples/2-animating-points.md
+++ b/examples/2-animating-points.md
@@ -1,9 +1,7 @@
 # Final Code
 
 ```
-var w = window.WebAnim
+var point = new Point({ x: 500, y: 500, color: Colors.Red(), size: 100 })
 
-var point = new w.Point({ x: 500, y: 500, color: w.Colors.Red(), size: 100 })
-
-w.scene.add(await w.Create(point))
+scene.add(await Create(point))
 ```

--- a/examples/3-number-plane.md
+++ b/examples/3-number-plane.md
@@ -1,9 +1,7 @@
 # Final Code
 
 ```
-var w = window.WebAnim
+var plane = new NumberPlane({ showGridLines: true })
 
-var plane = new w.NumberPlane({ showGridLines: true })
-
-w.scene.add(await w.Create(plane))
+scene.add(await Create(plane))
 ```

--- a/examples/4-plotting-points.md
+++ b/examples/4-plotting-points.md
@@ -1,11 +1,10 @@
 # Final Code
 
 ```
-var w = window.WebAnim
-var plane = new w.NumberPlane({ showGridLines: true })
+var plane = new NumberPlane({ showGridLines: true })
 
-w.scene.add(await w.FadeIn(plane))
-await w.scene.wait(1000)
+scene.add(await FadeIn(plane))
+await scene.wait(1000)
 
-plane.point({ x: -1, y: 1, transition: w.Transitions.Create, color: w.Colors.Orange(), size: 10 })
+plane.point({ x: -1, y: 1, transition: Transitions.Create, color: Colors.Orange(), size: 10 })
 ```

--- a/examples/5-plotting-functions.md
+++ b/examples/5-plotting-functions.md
@@ -1,13 +1,12 @@
 # Final Code
 
 ```
-var w = window.WebAnim
-var plane = new w.NumberPlane({ showGridLines: true })
+var plane = new NumberPlane({ showGridLines: true })
 
-w.scene.add(await w.FadeIn(plane))
-await w.scene.wait(1000)
+scene.add(await FadeIn(plane))
+await scene.wait(1000)
 
-plane.plot({ definition: 'y = sin(x)', color: w.Colors.Green(), thickness: 5, transition: w.Transitions.Create })
+plane.plot({ definition: 'y = sin(x)', color: Colors.Green(), thickness: 5, transition: Transitions.Create })
 ```
 
 ### Currently, only explicity functions are supported by AnimWeb. Support for Implicit and Parametric functions will come soon.

--- a/examples/6-tangent-to-function.md
+++ b/examples/6-tangent-to-function.md
@@ -1,17 +1,16 @@
 # Final Code
 
 ```
-var w = window.WebAnim
-var plane = new w.NumberPlane({ showGridLines: true })
+var plane = new NumberPlane({ showGridLines: true })
 
-w.scene.add(await w.FadeIn(plane))
-await w.scene.wait(1000)
+scene.add(await FadeIn(plane))
+await scene.wait(1000)
 
-var cosx = await plane.plot({ definition: 'y = cos(x)', color: w.Colors.Green(), thickness: 5, transition: w.Transitions.FadeIn })
-await w.scene.wait()
+var cosx = await plane.plot({ definition: 'y = cos(x)', color: Colors.Green(), thickness: 5, transition: Transitions.FadeIn })
+await scene.wait()
 
-var tangent = await cosx.addAnchorLine({ x: 0, color: w.Colors.Orange(), thickness: 3, transition: w.Transitions.Create })
-await w.scene.wait(1000)
+var tangent = await cosx.addAnchorLine({ x: 0, color: Colors.Orange(), thickness: 3, transition: Transitions.Create })
+await scene.wait(1000)
 
 tangent.moveTo({ x: Math.PI })
 ```

--- a/examples/7-fixed-length-tangent.md
+++ b/examples/7-fixed-length-tangent.md
@@ -1,20 +1,19 @@
 # Final Code
 
 ```
-var w = window.WebAnim
-var plane = new w.NumberPlane({ showGridLines: true })
-w.scene.add(await w.Create(plane))
+var plane = new NumberPlane({ showGridLines: true })
+scene.add(await Create(plane))
 
-await w.scene.wait(3000)
+await scene.wait(3000)
 
-var sinx = await plane.plot({ definition: 'y = sin(x)', transition: w.Transitions.Create, color: w.Colors.Green(), thickness: 5 })
+var sinx = await plane.plot({ definition: 'y = sin(x)', transition: Transitions.Create, color: Colors.Green(), thickness: 5 })
 
-await w.scene.wait()
+await scene.wait()
 
-var tangent = await sinx.addAnchorLine({ x: 0, transition: w.Transitions.Create, color: w.Colors.Orange(), thickness: 3, length: 4 })
-await w.scene.wait()
+var tangent = await sinx.addAnchorLine({ x: 0, transition: Transitions.Create, color: Colors.Orange(), thickness: 3, length: 4 })
+await scene.wait()
 tangent.moveTo({ x: 10, duration: 5 })
-await w.scene.wait()
+await scene.wait()
 ```
 
 ### The same length property can be passed to any line to control it's length too.

--- a/examples/8-anchor-points.md
+++ b/examples/8-anchor-points.md
@@ -1,19 +1,18 @@
 # Final Code
 
 ```
-var w = window.WebAnim
-var plane = new w.NumberPlane({ showGridLines: true })
-w.scene.add(await w.Create(plane))
+var plane = new NumberPlane({ showGridLines: true })
+scene.add(await Create(plane))
 
-await w.scene.wait(3000)
+await scene.wait(3000)
 
-var sinx = await plane.plot({ definition: 'y = sin(x)', transition: w.Transitions.Create, color: w.Colors.Green(), thickness: 5 })
+var sinx = await plane.plot({ definition: 'y = sin(x)', transition: Transitions.Create, color: Colors.Green(), thickness: 5 })
 
-await w.scene.wait()
+await scene.wait()
 
-var point = await sinx.addAnchorPoint({ x: 0, color: w.Colors.Orange(), size: 10, transition: w.Transitions.Create })
+var point = await sinx.addAnchorPoint({ x: 0, color: Colors.Orange(), size: 10, transition: Transitions.Create })
 
-await w.scene.wait(1000)
+await scene.wait(1000)
 
 await point.moveTo({ x: 5, duration: 2 })
 ```


### PR DESCRIPTION
1. Previous merge made some syntax updates where user didn't need to reference window.WebAnim, etc.
2. Updated the README.md and examples to comply with new syntax.
3. Old syntax still works and changes are backwards compatible.