### PR TITLE
Added Simpler Syntax and updated docs

### DIFF
--- a/examples/1-animating-lines.md
+++ b/examples/1-animating-lines.md
@@ -3,5 +3,5 @@
 ```
 var line = Line({ form: w.Lines.SlopePoint, slope: 1, point: {x: 0, y: 0}, color: w.Colors.Green(), thickness: 5 })
 
-scene.add(await Create(line, { duration: 10 }))
+Create(line, { duration: 10 })
 ```

--- a/examples/2-animating-points.md
+++ b/examples/2-animating-points.md
@@ -1,7 +1,7 @@
 # Final Code
 
 ```
-var point = new Point({ x: 500, y: 500, color: Colors.Red(), size: 100 })
+var point = Point({ x: 500, y: 500, color: Colors.Red(), size: 100 })
 
-scene.add(await Create(point))
+Create(point)
 ```

--- a/examples/3-number-plane.md
+++ b/examples/3-number-plane.md
@@ -1,7 +1,7 @@
 # Final Code
 
 ```
-var plane = new NumberPlane({ showGridLines: true })
+var plane = NumberPlane({ showGridLines: true })
 
-scene.add(await Create(plane))
+Create(plane)
 ```

--- a/examples/4-plotting-points.md
+++ b/examples/4-plotting-points.md
@@ -1,10 +1,10 @@
 # Final Code
 
 ```
-var plane = new NumberPlane({ showGridLines: true })
+var plane = NumberPlane({ showGridLines: true })
 
-scene.add(await FadeIn(plane))
-await scene.wait(1000)
+FadeIn(plane)
+await wait(1000)
 
 plane.point({ x: -1, y: 1, transition: Transitions.Create, color: Colors.Orange(), size: 10 })
 ```

--- a/examples/5-plotting-functions.md
+++ b/examples/5-plotting-functions.md
@@ -1,10 +1,10 @@
 # Final Code
 
 ```
-var plane = new NumberPlane({ showGridLines: true })
+var plane = NumberPlane({ showGridLines: true })
 
-scene.add(await FadeIn(plane))
-await scene.wait(1000)
+FadeIn(plane)
+await wait(1000)
 
 plane.plot({ definition: 'y = sin(x)', color: Colors.Green(), thickness: 5, transition: Transitions.Create })
 ```

--- a/examples/6-tangent-to-function.md
+++ b/examples/6-tangent-to-function.md
@@ -1,16 +1,16 @@
 # Final Code
 
 ```
-var plane = new NumberPlane({ showGridLines: true })
+var plane = NumberPlane({ showGridLines: true })
 
-scene.add(await FadeIn(plane))
-await scene.wait(1000)
+FadeIn(plane)
+await wait(1000)
 
 var cosx = await plane.plot({ definition: 'y = cos(x)', color: Colors.Green(), thickness: 5, transition: Transitions.FadeIn })
-await scene.wait()
+await wait()
 
 var tangent = await cosx.addAnchorLine({ x: 0, color: Colors.Orange(), thickness: 3, transition: Transitions.Create })
-await scene.wait(1000)
+await wait(1000)
 
 tangent.moveTo({ x: Math.PI })
 ```

--- a/examples/7-fixed-length-tangent.md
+++ b/examples/7-fixed-length-tangent.md
@@ -1,19 +1,19 @@
 # Final Code
 
 ```
-var plane = new NumberPlane({ showGridLines: true })
-scene.add(await Create(plane))
+var plane = NumberPlane({ showGridLines: true })
+Create(plane)
 
-await scene.wait(3000)
+await wait(3000)
 
 var sinx = await plane.plot({ definition: 'y = sin(x)', transition: Transitions.Create, color: Colors.Green(), thickness: 5 })
 
-await scene.wait()
+await wait()
 
 var tangent = await sinx.addAnchorLine({ x: 0, transition: Transitions.Create, color: Colors.Orange(), thickness: 3, length: 4 })
-await scene.wait()
+await wait()
 tangent.moveTo({ x: 10, duration: 5 })
-await scene.wait()
+await wait()
 ```
 
 ### The same length property can be passed to any line to control it's length too.

--- a/examples/8-anchor-points.md
+++ b/examples/8-anchor-points.md
@@ -1,18 +1,18 @@
 # Final Code
 
 ```
-var plane = new NumberPlane({ showGridLines: true })
-scene.add(await Create(plane))
+var plane = NumberPlane({ showGridLines: true })
+Create(plane)
 
-await scene.wait(3000)
+await wait(3000)
 
 var sinx = await plane.plot({ definition: 'y = sin(x)', transition: Transitions.Create, color: Colors.Green(), thickness: 5 })
 
-await scene.wait()
+await wait()
 
 var point = await sinx.addAnchorPoint({ x: 0, color: Colors.Orange(), size: 10, transition: Transitions.Create })
 
-await scene.wait(1000)
+await wait(1000)
 
 await point.moveTo({ x: 5, duration: 2 })
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,8 +35,8 @@ let WebAnim = {
   Colors: StandardColors,
   Width,
   Height,
-  wait,
-  show: (config: any) => scene.add(config),
+  wait: async (config: any) => scene.wait(config),
+  show: async (config: any) => scene.add(config),
   // AnimObjects
   NumberPlane: (config: any) => new NumberPlane(config),
   Line: (config: any) => new Line(config),
@@ -45,8 +45,8 @@ let WebAnim = {
   Text: (config: any) => new Text(config),
   ImplicitCurve: (config: any) => new ImplicitCurve(config),
   // transitions
-  Create,
-  FadeIn,
+  Create: async (config: any) => scene.add(await Create(config)),
+  FadeIn: async (config: any) => scene.add(await FadeIn(config)),
   FadeOut,
   // enums
   Transitions,


### PR DESCRIPTION
1. Now, instead of called scene.add, user can simply call show which completely abstracts the Scene from the user.
2. Create and FadeIn are now aliases for show(await Create()) and show(await FadeIn())
3. User doesn't need to differentiate between wait and scene.wait. The wait functon handles it automatically.