### PR TITLE
Improvements to Implicit function plotting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "mathjax-full": "^3.2.2",
         "mathjs": "^11.7.0",
         "p5": "^1.6.0",
+        "svg-text": "^0.5.1",
         "svg64": "^2.0.0",
         "uuid": "^9.0.0",
         "vite-plugin-top-level-await": "^1.3.0"
@@ -1018,6 +1019,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/svg-text": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/svg-text/-/svg-text-0.5.1.tgz",
+      "integrity": "sha512-4u6LsA6IdbhBOynsrnxQ9bXMLGd3ScDOyuauJGE6HpR7yq87PcGNzOkDmIezg/YhwYAhGBXODLE/QeFlNMijQQ=="
     },
     "node_modules/svg64": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mathjax-full": "^3.2.2",
     "mathjs": "^11.7.0",
     "p5": "^1.6.0",
+    "svg-text": "^0.5.1",
     "svg64": "^2.0.0",
     "uuid": "^9.0.0",
     "vite-plugin-top-level-await": "^1.3.0"

--- a/src/animweb/AnimObject.ts
+++ b/src/animweb/AnimObject.ts
@@ -76,6 +76,7 @@ export default class AnimObject {
   queueTransition: Function = () => {}
   unqueueTransition: Function = () => {}
   waitBeforeTransition: Function = () => {}
+  remove?: Function
   parentData: {
     origin: { x: number; y: number }
     stepX: number

--- a/src/animweb/AnimObjects/Curve.ts
+++ b/src/animweb/AnimObjects/Curve.ts
@@ -55,7 +55,18 @@ export default class Curve extends AnimObject {
     parentData,
   }: CurveProps) {
     super()
-    this.y = definition
+    let temp = definition
+    let parts = temp.split('=')
+    if (parts.length == 1) this.y = definition
+    else {
+      temp = parts[0]
+      for (let part of parts) {
+        if (part == parts[0]) continue
+        temp = `${temp} - (${part})`
+      }
+      console.log(temp)
+      this.y = temp
+    }
     this.sampleRate = sampleRate
     this.domain = domain
     this.range = range
@@ -77,10 +88,9 @@ export default class Curve extends AnimObject {
   getFunctionValues() {
     let h = (this.domain[1] - this.domain[0]) / this.sampleRate
     let rhs = this.y
-    if (rhs.includes('=')) rhs = rhs.split('=')[1]
     for (let x = this.domain[0]; x <= this.domain[1]; x += h) {
-      let y = evaluate(rhs, { x })
-      this.points.push({ x, y })
+      let y = evaluate(rhs, { x, y: 0 })
+      this.points.push({ x, y: -y })
     }
   }
 

--- a/src/animweb/AnimObjects/Curve.ts
+++ b/src/animweb/AnimObjects/Curve.ts
@@ -135,42 +135,39 @@ export default class Curve extends AnimObject {
     })
   }
 
-  addAnchorLine(config: CurveAnchorLineProps): Promise<Line> {
-    return new Promise(async (resolve, reject) => {
-      let x = config.x
-      let y = evaluate(this.y, { x })
-      let point = {
-        x: x * this.parentData.stepX,
-        y: y * this.parentData.stepY,
-      }
-      let parts = this.y.split('=')
-      let rhs = parts[parts.length - 1]
-      let length = config.length ? config.length : this.parentData.stepX * 2
-      let transition = Transition(
-        config.transition ? config.transition : Transitions.None
-      )
-      let line = await transition(
-        new Line({
-          ...config,
-          form: Lines.SlopePoint,
-          slope: derivative(rhs, 'x').evaluate({ x }),
-          point,
-          definition: this.y,
-          parentData: {
-            stepX: this.parentData.stepX,
-            stepY: this.parentData.stepY,
-            origin: this.parentData.origin,
-          },
-        }),
-        config.transitionOptions ? config.transitionOptions : {}
-      )
-      if (line instanceof Line) {
-        this.anchorLines.push(line)
-        resolve(line)
-      } else {
-        reject()
-      }
-    })
+  addTangent(config: CurveAnchorLineProps): Line {
+    let x = config.x
+    let y = evaluate(this.y, { x })
+    let point = {
+      x: x * this.parentData.stepX,
+      y: y * this.parentData.stepY,
+    }
+    let parts = this.y.split('=')
+    let rhs = parts[parts.length - 1]
+    console.log(parts)
+    // let length = config.length ? config.length : this.parentData.stepX * 2
+    let transition = Transition(
+      config.transition ? config.transition : Transitions.None
+    )
+    let line = transition<Line>(
+      new Line({
+        ...config,
+        form: Lines.SlopePoint,
+        slope: derivative(rhs, 'x').evaluate({ x }),
+        point,
+        definition: this.y,
+        parentData: {
+          stepX: this.parentData.stepX,
+          stepY: this.parentData.stepY,
+          origin: this.parentData.origin,
+        },
+      }),
+      config.transitionOptions ? config.transitionOptions : {}
+    )
+    if (line instanceof Line) {
+      this.anchorLines.push(line)
+    }
+    return line
   }
 
   draw(p: p5) {

--- a/src/animweb/AnimObjects/ImplicitCurve.ts
+++ b/src/animweb/AnimObjects/ImplicitCurve.ts
@@ -17,7 +17,7 @@ export default class ImplicitCurve extends AnimObject {
   quadTree?: any
   thickness: number = 1
   color: Color = Colors.black
-  sampleRate: number = 9
+  sampleRate: number = 6
   calculatingQuadtree: boolean = false
   webWorker: Worker = new Worker(
     new URL('./../helpers/QuadTree.worker.js', import.meta.url),
@@ -28,7 +28,18 @@ export default class ImplicitCurve extends AnimObject {
 
   constructor(config: ImplicitCurveProps) {
     super()
-    this.definition = config.definition
+    let temp = config.definition
+    let parts = temp.split('=')
+    if (parts.length == 1) this.definition = config.definition
+    else {
+      temp = parts[0]
+      for (let part of parts) {
+        if (part == parts[0]) continue
+        temp = `${temp} - (${part})`
+      }
+      console.log(temp)
+      this.definition = temp
+    }
     if (config.parentData) {
       this.parentData = {
         ...this.parentData,

--- a/src/animweb/AnimObjects/ImplicitCurve.ts
+++ b/src/animweb/AnimObjects/ImplicitCurve.ts
@@ -8,18 +8,12 @@ import { roundOff } from '../helpers/miscellaneous'
 interface ImplicitCurveProps extends AnimObjectProps {
   definition: string
   sampleRate?: number
-  stepX: number
-  stepY: number
-  origin: { x: number; y: number }
   thickness?: number
   color?: Color
 }
 
 export default class ImplicitCurve extends AnimObject {
   definition: string = ''
-  stepX: number
-  stepY: number
-  origin: { x: number; y: number }
   quadTree?: any
   thickness: number = 1
   color: Color = Colors.black
@@ -35,19 +29,15 @@ export default class ImplicitCurve extends AnimObject {
   constructor(config: ImplicitCurveProps) {
     super()
     this.definition = config.definition
-    this.stepX = config.stepX
-    this.stepY = config.stepY
-    this.origin = config.origin
+    if (config.parentData) {
+      this.parentData = {
+        ...this.parentData,
+        ...config.parentData,
+      }
+    }
     if (config.thickness) this.thickness = config.thickness
     if (config.color) this.color = config.color
     if (config.sampleRate) this.sampleRate = config.sampleRate / 100
-  }
-
-  interpolate(x1: number, y1: number, x2: number, y2: number) {
-    let r = -y2 / (y1 - y2)
-
-    if (r >= 0 && r <= 1) return r * (x1 - x2) + x2
-    return (x1 + x2) * 0.5
   }
 
   calculateQuadtree() {
@@ -60,9 +50,9 @@ export default class ImplicitCurve extends AnimObject {
         height: this.sceneHeight,
         definition: this.definition,
         depth: 0,
-        origin: this.origin,
-        stepX: this.stepX,
-        stepY: this.stepY,
+        origin: this.parentData.origin,
+        stepX: this.parentData.stepX,
+        stepY: this.parentData.stepY,
         maxDepth: this.sampleRate,
         id: this.id,
       })

--- a/src/animweb/AnimObjects/Line.ts
+++ b/src/animweb/AnimObjects/Line.ts
@@ -130,8 +130,9 @@ export default class Line extends AnimObject {
       case Lines.DoublePoint:
         let { x1: X1, y1: Y1, x2: X2, y2: Y2 } = config
         let { x: x1, y: y1 } = this.getAbsolutePosition({ x: X1, y: Y1 })
+        y1 *= -1
         let s = (Y2 - Y1) / (X2 - X1)
-        this.setSlope(-s)
+        this.setSlope(s)
         let c = y1 - this.slope * x1
         this.offset = c
         this.x = (y: number) => x1
@@ -392,8 +393,6 @@ export default class Line extends AnimObject {
       )
     }
 
-    let p1 = this.getAbsolutePosition({ x: 1, y: 1 })
-    let p2 = this.getAbsolutePosition({ x: 2, y: 2 })
     p.translate(-this.parentData.origin.x, -this.parentData.origin.y)
     p.noStroke()
   }

--- a/src/animweb/Scene.ts
+++ b/src/animweb/Scene.ts
@@ -179,6 +179,7 @@ export default class Scene {
   }
 
   resetScene() {
+    for (let object of this.objects) if (object.remove) object.remove()
     this.objects = []
     this.transitionQueue = []
   }

--- a/src/animweb/Transition.ts
+++ b/src/animweb/Transition.ts
@@ -22,16 +22,24 @@ export enum Transitions {
   None = 'None',
 }
 
-export const Transition = (type: Transitions) => {
+type TrasitionReturnType = <Object extends AnimObject>(
+  obj: Object,
+  config: any
+) => Object
+
+export const Transition = (type: Transitions): TrasitionReturnType => {
   switch (type) {
     case Transitions.FadeIn:
-      return FadeIn
+      return <Object extends AnimObject>(obj: Object, config: any) =>
+        FadeIn<Object>(obj, config)
     case Transitions.FadeOut:
-      return FadeOut
+      return <Object extends AnimObject>(obj: Object, config: any) =>
+        FadeOut<Object>(obj, config)
     case Transitions.Create:
-      return Create
+      return <Object extends AnimObject>(obj: Object, config: any) =>
+        Create<Object>(obj, config)
     default:
-      return (object: AnimObject, config: TransitionProps) => object
+      return <Object extends AnimObject>(object: Object, config: any) => object
   }
 }
 

--- a/src/animweb/transitions/Create.ts
+++ b/src/animweb/transitions/Create.ts
@@ -247,10 +247,10 @@ const createPointTransitions = async (
   }
 }
 
-const Create = (
-  object: AnimObject,
+const Create = <Object extends AnimObject>(
+  object: Object,
   config: CreateTransitionProps = {}
-): AnimObject => {
+): Object => {
   if (object instanceof Line) {
     object.transition = createLineTransition(object, config)
   }

--- a/src/animweb/transitions/FadeIn.ts
+++ b/src/animweb/transitions/FadeIn.ts
@@ -109,10 +109,10 @@ const fadeInTransitions = (
   )
 }
 
-const FadeIn = (
-  object: AnimObject,
+const FadeIn = <Object extends AnimObject>(
+  object: Object,
   config: FadeInTransitionProps = {}
-): AnimObject => {
+): Object => {
   if (object instanceof Line) {
     resetColor(object)
     object.transition = fadeInTransition(object, config)

--- a/src/animweb/transitions/FadeOut.ts
+++ b/src/animweb/transitions/FadeOut.ts
@@ -112,10 +112,10 @@ const fadeOutTransitions = (
   )
 }
 
-const FadeOut = (
-  object: AnimObject,
+const FadeOut = <Object extends AnimObject>(
+  object: Object,
   config: FadeOutTransitionProps = {}
-): AnimObject => {
+): Object => {
   if (object instanceof Line) {
     resetColor(object)
     object.transition = fadeOutTransition(object, config)

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,9 +11,8 @@ import Curve from './animweb/AnimObjects/Curve'
 import Color from './animweb/helpers/Color'
 import { Transitions } from './animweb/Transition'
 import Text, { TextStyle } from './animweb/AnimObjects/Text'
-import { Observables, AnimObjects } from './animweb/AnimObject'
+import AnimObject, { Observables, AnimObjects } from './animweb/AnimObject'
 import Constants from './animweb/helpers/Constants'
-import { wait } from './animweb/helpers/miscellaneous'
 import ImplicitCurve from './animweb/AnimObjects/ImplicitCurve'
 import LaTeX from './animweb/AnimObjects/LaTeX'
 
@@ -51,8 +50,10 @@ let WebAnim = {
   TeX: (config: any) => new LaTeX(config),
   Tex: (config: any) => new LaTeX(config),
   // transitions
-  Create: (config: any) => scene.add(Create(config)),
-  FadeIn: (config: any) => scene.add(FadeIn(config)),
+  Create: (object: AnimObject, config: any) =>
+    scene.add(Create(object, config)),
+  FadeIn: (object: AnimObject, config: any) =>
+    scene.add(FadeIn(object, config)),
   FadeOut,
   // enums
   Transitions,

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,9 +35,7 @@ let WebAnim = {
   Width,
   Height,
   wait: async (config: any) => scene.wait(config),
-  show: async (config: any) => {
-    scene.add(config)
-  },
+  show: (config: any) => scene.add(config),
   // AnimObjects
   NumberPlane: (config: any) => new NumberPlane(config),
   Line: (config: any) => new Line(config),


### PR DESCRIPTION
1. Implemented lerp (properly this time) so that smooth curves are drawn even at lower quadtree depths.
2. Lerp significantly improves implicit curve render time
3. Implicit curves can now be passed in the form f(x, y) = c (in addition to the f(x, y) - c = 0)