### PR TITLE
Importing an AnimObject now imports all the enums related to it.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       "@transitions/*": ["./src/transitions/*"],
       "@ui/*": ["./src/ui/*"],
       "@workers/*": ["./src/workers/*"],
+      "@enums/*": ["./src/enums/*"],
     }
   },
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
       { find: '@AnimObjects2D', replacement: fileURLToPath(new URL('./src/AnimObjects2D', import.meta.url)) },
       { find: '@AnimObjects3D', replacement: fileURLToPath(new URL('./src/AnimObjects3D', import.meta.url)) },
       { find: '@workers', replacement: fileURLToPath(new URL('./src/workers', import.meta.url)) },
+      { find: '@enums', replacement: fileURLToPath(new URL('./src/enums', import.meta.url)) },
     ],
   }
 });


### PR DESCRIPTION
1. Done to improve speed and reduce bundle size.