### PR TITLE
More improvements to dynamically importing Scene3D

### DIFF
--- a/core/main.ts
+++ b/core/main.ts
@@ -1,6 +1,5 @@
 // Core
 import Scene2D from './Scene2D.ts'
-// import Scene3D from './Scene3D.ts'
 import AnimObject2D from './AnimObject2D.ts'
 import AnimObject3D from './AnimObject3D.ts'
 
@@ -67,7 +66,6 @@ import { createPrompt } from '@mixins/Prompt.ts'
 import { watch } from '@mixins/Watcher.ts'
 
 let scene2D = new Scene2D(Width.full, Height.full, Colors.gray0)
-// let scene3D = new Scene3D(Width.full, Height.full, Colors.gray0)
 let scene3D: any
 
 scene2D.show()
@@ -78,10 +76,11 @@ scene = scene2D
 const init3DScene = (): Promise<void> => {
   return new Promise((resolve, reject) => {
     if (scene3D) resolve(scene3D)
-    else import('./Scene3D.ts').then(module => {
-      scene3D = new module.default(Width.full, Height.full, Colors.gray0)
-      resolve(scene3D)
-    })
+    else
+      import('./Scene3D.ts').then(module => {
+        scene3D = new module.default(Width.full, Height.full, Colors.gray0)
+        resolve(scene3D)
+      })
   })
 }
 
@@ -126,7 +125,10 @@ export default () => {
     degToRad,
     radToDeg,
     resetScene,
-    init3DScene
+    init3DScene,
+    scene3DInitialised() {
+      return Boolean(scene3D)
+    },
   }
 
   const enums = {

--- a/core/main.ts
+++ b/core/main.ts
@@ -15,12 +15,19 @@ import Vector from '@AnimObjects2D/Vector.ts'
 import ComplexPlane2D from '@AnimObjects2D/ComplexPlane2D.ts'
 
 // AnimObjects3D
-import Point3D from '@AnimObjects3D/Point3D.ts'
-import Line3D from '@AnimObjects3D/Line3D.ts'
-import Surface from '@AnimObjects3D/Surface.ts'
-import NumberPlane3D from '@AnimObjects3D/NumberPlane3D.ts'
-import ComplexPlane3D from '@AnimObjects3D/ComplexPlane3D.ts'
-import Text3D from '@AnimObjects3D/Text3D.ts'
+// import Point3D from '@AnimObjects3D/Point3D.ts'
+// import Line3D from '@AnimObjects3D/Line3D.ts'
+// import Surface from '@AnimObjects3D/Surface.ts'
+// import NumberPlane3D from '@AnimObjects3D/NumberPlane3D.ts'
+// import ComplexPlane3D from '@AnimObjects3D/ComplexPlane3D.ts'
+// import Text3D from '@AnimObjects3D/Text3D.ts'
+
+let Point3D: any
+let Line3D: any
+let Surface: any
+let NumberPlane3D: any
+let ComplexPlane3D: any
+let Text3D: any
 
 // Auxiliary
 import Color from '@auxiliary/Color.ts'
@@ -58,9 +65,12 @@ import { prompts } from '@reactives/prompts.ts'
 import FadeIn from '@transitions/FadeIn.ts'
 import FadeOut from '@transitions/FadeOut.ts'
 import Create from '@transitions/Create.ts'
-import Create3D from '@transitions/Create3D.ts'
-import FadeIn3D from '@transitions/FadeIn3D.ts'
-import FadeOut3D from '@transitions/FadeOut3D.ts'
+// import Create3D from '@transitions/Create3D.ts'
+// import FadeIn3D from '@transitions/FadeIn3D.ts'
+// import FadeOut3D from '@transitions/FadeOut3D.ts'
+let Create3D: any
+let FadeIn3D: any
+let FadeOut3D: any
 
 import { createPrompt } from '@mixins/Prompt.ts'
 import { watch } from '@mixins/Watcher.ts'
@@ -74,13 +84,31 @@ let scene: Scene = scene2D
 scene = scene2D
 
 const init3DScene = (): Promise<void> => {
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     if (scene3D) resolve(scene3D)
-    else
-      import('./Scene3D.ts').then(module => {
-        scene3D = new module.default(Width.full, Height.full, Colors.gray0)
-        resolve(scene3D)
-      })
+    else {
+      let scene3DModule = await import('./Scene3D.ts')
+      scene3D = new scene3DModule.default(Width.full, Height.full, Colors.gray0)
+      let point3DModule = await import('@AnimObjects3D/Point3D.ts')
+      Point3D = point3DModule.default
+      let line3DModule = await import('@AnimObjects3D/Line3D.ts')
+      Line3D = line3DModule.default
+      let surfaceModule = await import('@AnimObjects3D/Surface.ts')
+      Surface = surfaceModule.default
+      let numberPlane3DModule = await import('@AnimObjects3D/NumberPlane3D.ts')
+      NumberPlane3D = numberPlane3DModule.default
+      let complexPlane3DModule = await import('@AnimObjects3D/ComplexPlane3D.ts')
+      ComplexPlane3D = complexPlane3DModule.default
+      let text3DModule = await import('@AnimObjects3D/Text3D.ts')
+      Text3D = text3DModule.default
+      let create3DModule = await import('@transitions/Create3D.ts')
+      Create3D = create3DModule.default
+      let fadeIn3DModule = await import('@transitions/FadeIn3D.ts')
+      FadeIn3D = fadeIn3DModule.default
+      let fadeOut3DModule = await import('@transitions/FadeOut3D.ts')
+      FadeOut3D = fadeOut3DModule.default
+      resolve(scene3D)
+    }
   })
 }
 
@@ -94,7 +122,7 @@ const resetScene = (clearDebuggingData = false) => {
   buttons.clear()
   prompts.clear()
   scene2D.resetScene()
-  scene3D.resetScene()
+  scene3D?.resetScene()
 }
 
 export default () => {

--- a/interfaces/ui.ts
+++ b/interfaces/ui.ts
@@ -27,6 +27,7 @@ export interface EditorReactive extends UIReactive {
   editor: any
   create: Function
   run: Function
+  disabled: boolean
 }
 
 export interface CodeReactive {

--- a/pages/animate.vue
+++ b/pages/animate.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted } from 'vue'
 import { editor } from '@reactives/editor.ts'
-
-const disabled = ref(true)
 
 onMounted(() => {
   editor.create()
@@ -12,7 +10,7 @@ onMounted(() => {
       // @ts-ignore
       if (window.WebAnim) {
         console.log('ready')
-        disabled.value = false
+        editor.disabled = false
       }
     })
   }
@@ -23,8 +21,8 @@ onMounted(() => {
   <Head>
     <Title>Animweb - Start creating your animation now!</Title>
   </Head>
-  <Controls :disabled="disabled" />
-  <Interactables :disabled="disabled" />
+  <Controls :disabled="editor.disabled" />
+  <Interactables :disabled="editor.disabled" />
 </template>
 
 <style lang="stylus">

--- a/reactives/code.ts
+++ b/reactives/code.ts
@@ -1,5 +1,6 @@
 import { reactive } from 'vue'
 import { CodeReactive } from '@interfaces/ui.ts'
+import { editor } from './editor'
 
 const code: CodeReactive = reactive<CodeReactive>({
   hidden: false,
@@ -16,8 +17,12 @@ const code: CodeReactive = reactive<CodeReactive>({
   },
   async toggleMode() {
     code.mode = code.mode == '2D' ? '3D' : '2D'
-    if (code.mode == '3D') await window.WebAnim.init3DScene()
-    window.WebAnim.render(code.mode)
+    if (code.mode == '3D' && !window.WebAnim.scene3DInitialised()) {
+      editor.disabled = true
+      await window.WebAnim.init3DScene()
+      editor.disabled = false
+    }
+    window.WebAnim.render(code.mode, () => (editor.disabled = !editor.disabled))
   },
 })
 

--- a/reactives/editor.ts
+++ b/reactives/editor.ts
@@ -12,6 +12,7 @@ declare global {
 
 export const editor: EditorReactive = reactive<EditorReactive>({
   editor: null,
+  disabled: true,
   create() {
     let defaultCode = `var plane = Create(NumberPlane())
 await wait(2000)`


### PR DESCRIPTION
1. Now, none of the 3D modules are downloaded by default.
2. Hence, the app starts up in 2D mode.
3. When user switches to 3D for the first time, we import all 3D modules (transitions, Scene, AnimObjects, etc.)
4. This will reduce bundle size.