### PR TITLE
Improved WASM interop with Nuxt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .env
 dist
 .DS_Store
+public/wasm_bg.wasm

--- a/composables/useWASM.ts
+++ b/composables/useWASM.ts
@@ -2,7 +2,7 @@
 import init, { greet, himom, add, sub } from './../wasm/pkg/wasm.js'
 
 export default async () => {
-  await init('@/public/wasm_bg.wasm')
+  await init('/wasm_bg.wasm')
   return {
     greet,
     himom,

--- a/composables/useWASM.ts
+++ b/composables/useWASM.ts
@@ -1,9 +1,12 @@
 // @ts-ignore
-import init, { greet } from 'wasm'
+import init, { greet, himom, add, sub } from './../wasm/pkg/wasm.js'
 
 export default async () => {
-  await init(await fetch('wasm_bg.wasm'))
+  await init('@/public/wasm_bg.wasm')
   return {
     greet,
+    himom,
+    add,
+    sub,
   }
 }

--- a/composables/useWASM.ts
+++ b/composables/useWASM.ts
@@ -1,11 +1,9 @@
 // @ts-ignore
-import init, { greet, himom, add, sub } from './../wasm/pkg/wasm.js'
+import init, { add, sub } from './../wasm/pkg/wasm.js'
 
 export default async () => {
   await init('/wasm_bg.wasm')
   return {
-    greet,
-    himom,
     add,
     sub,
   }

--- a/core/main.ts
+++ b/core/main.ts
@@ -77,6 +77,7 @@ let Morph3D: any
 
 let w = await useWASM()
 console.log(w.greet())
+w.himom('bruhhhh')
 import { watch } from '@mixins/Watcher.ts'
 
 let scene2D = new Scene2D(Width.full, Height.full, Colors.gray0)

--- a/core/main.ts
+++ b/core/main.ts
@@ -75,9 +75,7 @@ let FadeIn3D: any
 let FadeOut3D: any
 let Morph3D: any
 
-let w = await useWASM()
-console.log(w.greet())
-w.himom('bruhhhh')
+console.log((await useWASM()).add(1, 2))
 import { watch } from '@mixins/Watcher.ts'
 
 let scene2D = new Scene2D(Width.full, Height.full, Colors.gray0)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,8 +4,6 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills'
 // @ts-ignore
 import topLevelAwait from 'vite-plugin-top-level-await'
 // @ts-ignore
-import wasmPackPlugin from 'vite-plugin-wasm-pack'
-// @ts-ignore
 
 export default defineNuxtConfig({
   runtimeConfig: {
@@ -68,7 +66,6 @@ export default defineNuxtConfig({
         protocolImports: true,
       }),
       topLevelAwait(),
-      wasmPackPlugin('./wasm'),
     ],
     resolve: {
       extensions: ['.js', '.ts', '.css'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,7 @@
         "vectorize-text": "^3.2.2",
         "vite-plugin-node-polyfills": "^0.8.2",
         "vite-plugin-static-copy": "^0.16.0",
-        "vite-plugin-top-level-await": "^1.3.1",
-        "vite-plugin-wasm": "^3.2.2",
-        "vite-plugin-wasm-pack": "^0.1.12"
+        "vite-plugin-top-level-await": "^1.3.1"
       },
       "devDependencies": {
         "@types/node": "^18",
@@ -8733,11 +8731,6 @@
         "node": "^14 || ^16 || >=18"
       }
     },
-    "node_modules/narrowing": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/narrowing/-/narrowing-1.5.0.tgz",
-      "integrity": "sha512-DUu4XdKgkfAPTAL28k79pdnshDE2W5T24QAnidSPo2F/W1TX6CjNzmEeXQfE5O1lxQvC0GYI6ZRDsLcyzugEYA=="
-    },
     "node_modules/ndarray": {
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
@@ -15798,71 +15791,6 @@
       },
       "peerDependencies": {
         "vite": ">=2.8"
-      }
-    },
-    "node_modules/vite-plugin-wasm": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.2.2.tgz",
-      "integrity": "sha512-cdbBUNR850AEoMd5nvLmnyeq63CSfoP1ctD/L2vLk/5+wsgAPlAVAzUK5nGKWO/jtehNlrSSHLteN+gFQw7VOA==",
-      "peerDependencies": {
-        "vite": "^2 || ^3 || ^4"
-      }
-    },
-    "node_modules/vite-plugin-wasm-pack": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/vite-plugin-wasm-pack/-/vite-plugin-wasm-pack-0.1.12.tgz",
-      "integrity": "sha512-WliYvQp9HXluir4OKGbngkcKxtYtifU11cqLurRRJGsl770Sjr1iIkp5RuvU3IC1poT4A57Z2/YgAKI2Skm7ZA==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "fs-extra": "^10.0.0",
-        "narrowing": "^1.4.0"
-      }
-    },
-    "node_modules/vite-plugin-wasm-pack/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/vite-plugin-wasm-pack/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite-plugin-wasm-pack/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/vite-plugin-wasm-pack/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "vectorize-text": "^3.2.2",
     "vite-plugin-node-polyfills": "^0.8.2",
     "vite-plugin-static-copy": "^0.16.0",
-    "vite-plugin-top-level-await": "^1.3.1",
-    "vite-plugin-wasm-pack": "^0.1.12"
+    "vite-plugin-top-level-await": "^1.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     {
       "from": "./wasm/pkg/wasm_bg.wasm",
       "to": "./public/wasm_bg.wasm"
+    },
+    {
+      "from": "./wasm/pkg/wasm.js",
+      "to": "./public/wasm.js"
     }
   ],
   "copyFilesSettings": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,6 @@
     {
       "from": "./wasm/pkg/wasm_bg.wasm",
       "to": "./public/wasm_bg.wasm"
-    },
-    {
-      "from": "./wasm/pkg/wasm.js",
-      "to": "./public/wasm.js"
     }
   ],
   "copyFilesSettings": {

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -7,11 +7,15 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2.63"
+
+[dependencies.web-sys]
+version = "0.3.63"
+features = [
+  "console"
+]
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -8,12 +8,33 @@ use wasm_bindgen::prelude::*;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+
 #[wasm_bindgen]
 extern {
     fn alert(s: &str);
+    fn parseInt(s: f32) -> i32;
 }
+
 
 #[wasm_bindgen]
 pub fn greet() {
     alert("Hello, wasm!");
+}
+
+
+
+#[wasm_bindgen]
+pub fn himom(string: &str) {
+    use web_sys::console;
+    console::log_1(&(format!("heheboi {}", string)).into());
+}
+
+#[wasm_bindgen]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[wasm_bindgen]
+pub fn sub(a: i32, b: i32) -> i32 {
+    a - b
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -15,19 +15,11 @@ extern {
     fn parseInt(s: f32) -> i32;
 }
 
-
-#[wasm_bindgen]
-pub fn greet() {
-    alert("Hello, wasm!");
-}
-
-
-
-#[wasm_bindgen]
-pub fn himom(string: &str) {
-    use web_sys::console;
-    console::log_1(&(format!("heheboi {}", string)).into());
-}
+// #[wasm_bindgen]
+// pub fn himom(string: &str) {
+//     use web_sys::console;
+//     console::log_1(&(format!("heheboi {}", string)).into());
+// }
 
 #[wasm_bindgen]
 pub fn add(a: i32, b: i32) -> i32 {


### PR DESCRIPTION
1. Removed dependency of vite-plugin-wasm-pack. WASM now directly loads from the wasm/pkg/wasm.js file.
2. During development, when rust code changes, WASM is automatically built and copied to public folder of Nuxt.
3. During production, vercel automatically installs rust and wasm-pac before building wasm. Thus, built binary isn't pushed to git.
4. Exported dummy add and subtract functions from lib.rs for tetsing purpose. This will be replaced with actual code for calculating the quadtree in a future commit.